### PR TITLE
fix: contact form stuck on success screen, add reset and i18n pending text (closes #19)

### DIFF
--- a/app/features/home/components/Contact.tsx
+++ b/app/features/home/components/Contact.tsx
@@ -8,11 +8,11 @@ import { siteConfig } from "../../../lib/data/content";
 import { sendContactEmail } from "../../../actions/contact";
 import { motion } from "framer-motion";
 
-function ContactForm() {
+function ContactForm({ onReset }: { onReset: () => void }) {
   const { t } = useLanguage();
   const [state, action, pending] = useActionState(sendContactEmail, null);
   const [formData, setFormData] = useState({ name: "", email: "", message: "" });
-  
+
   const isFormValid = formData.name.trim() && formData.email.trim() && formData.message.trim();
 
   if (state?.success) {
@@ -29,7 +29,13 @@ function ContactForm() {
           </svg>
         </div>
         <p className="text-white text-xl font-medium mb-2">{t.contact.successTitle}</p>
-        <p className="text-gray-500">{t.contact.successBody}</p>
+        <p className="text-gray-500 mb-6">{t.contact.successBody}</p>
+        <button
+          onClick={onReset}
+          className="text-xs font-semibold tracking-[0.08em] uppercase text-blue-400 hover:text-blue-300 transition-colors"
+        >
+          {t.contact.sendAnother}
+        </button>
       </motion.div>
     );
   }
@@ -107,7 +113,7 @@ function ContactForm() {
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
             </svg>
-            Sending...
+            {t.contact.sending}
           </span>
         ) : (
           t.contact.send
@@ -120,6 +126,7 @@ function ContactForm() {
 export default function Contact() {
   const { t } = useLanguage();
   const { email, location, mapEmbed } = siteConfig.contact;
+  const [formKey, setFormKey] = useState(0);
 
   return (
     <section id="contact" className="py-28 md:py-40 border-t border-white/[0.07] relative overflow-hidden">
@@ -216,7 +223,7 @@ export default function Contact() {
               <h3 className="text-lg font-semibold text-white mb-6">
                 {t.contact.formTitle}
               </h3>
-              <ContactForm />
+              <ContactForm key={formKey} onReset={() => setFormKey((k) => k + 1)} />
             </div>
           </FadeIn>
         </div>

--- a/app/lib/data/content.ts
+++ b/app/lib/data/content.ts
@@ -82,8 +82,10 @@ export const translations = {
       emailPlaceholder: "your@email.com",
       messagePlaceholder: "How can we help you?",
       send: "Send →",
+      sending: "Sending...",
       successTitle: "Message sent!",
       successBody: "We'll be in touch soon.",
+      sendAnother: "Send another message",
     },
     footer: {
       location: "Trondheim, Norway",
@@ -151,8 +153,10 @@ export const translations = {
       emailPlaceholder: "din@epost.no",
       messagePlaceholder: "Hvordan kan vi hjelpe deg?",
       send: "Send →",
+      sending: "Sender...",
       successTitle: "Melding sendt!",
       successBody: "Vi tar kontakt snart.",
+      sendAnother: "Send en ny melding",
     },
     footer: {
       location: "Trondheim, Norge",


### PR DESCRIPTION
After a successful contact form submission the form permanently showed the success screen with no way to send again short of reloading the page. A "send another message" button now appears on the success screen; clicking it increments a key on the ContactForm component, fully remounting it and resetting useActionState. The hardcoded English "Sending..." button label was also wired to the i18n system with new sending and sendAnother keys in both English and Norwegian translations.