### PR TITLE
fix: localize contact form validation errors by language (closes #21)

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -11,16 +11,47 @@ export type ContactState = {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
 
-function validate(name: string, email: string, message: string): string | null {
-  if (!name) return "Please enter your name.";
-  if (name.length < 2) return "Name must be at least 2 characters.";
-  if (name.length > 100) return "Name must be less than 100 characters.";
-  if (!email) return "Please enter your email.";
-  if (email.length > 254) return "Email must be less than 254 characters.";
-  if (!EMAIL_RE.test(email)) return "Please enter a valid email address.";
-  if (!message) return "Please enter a message.";
-  if (message.length < 10) return "Message must be at least 10 characters.";
-  if (message.length > 5000) return "Message must be less than 5000 characters.";
+const MESSAGES = {
+  en: {
+    name_empty: "Please enter your name.",
+    name_short: "Name must be at least 2 characters.",
+    name_long: "Name must be less than 100 characters.",
+    email_empty: "Please enter your email.",
+    email_long: "Email must be less than 254 characters.",
+    email_invalid: "Please enter a valid email address.",
+    message_empty: "Please enter a message.",
+    message_short: "Message must be at least 10 characters.",
+    message_long: "Message must be less than 5000 characters.",
+    service_error: "Email service not configured.",
+    send_failed: "Failed to send. Please try again.",
+  },
+  no: {
+    name_empty: "Vennligst oppgi ditt navn.",
+    name_short: "Navnet må være minst 2 tegn.",
+    name_long: "Navnet kan ikke være mer enn 100 tegn.",
+    email_empty: "Vennligst oppgi din e-postadresse.",
+    email_long: "E-postadressen kan ikke være mer enn 254 tegn.",
+    email_invalid: "Vennligst oppgi en gyldig e-postadresse.",
+    message_empty: "Vennligst skriv en melding.",
+    message_short: "Meldingen må være minst 10 tegn.",
+    message_long: "Meldingen kan ikke være mer enn 5000 tegn.",
+    service_error: "E-posttjeneste ikke konfigurert.",
+    send_failed: "Sending mislyktes. Prøv igjen.",
+  },
+};
+
+type Messages = typeof MESSAGES.en;
+
+function validate(name: string, email: string, message: string, m: Messages): string | null {
+  if (!name) return m.name_empty;
+  if (name.length < 2) return m.name_short;
+  if (name.length > 100) return m.name_long;
+  if (!email) return m.email_empty;
+  if (email.length > 254) return m.email_long;
+  if (!EMAIL_RE.test(email)) return m.email_invalid;
+  if (!message) return m.message_empty;
+  if (message.length < 10) return m.message_short;
+  if (message.length > 5000) return m.message_long;
   return null;
 }
 
@@ -28,16 +59,19 @@ export async function sendContactEmail(
   _prevState: ContactState,
   formData: FormData,
 ): Promise<ContactState> {
+  const lang = formData.get("lang") === "no" ? "no" : "en";
+  const m = MESSAGES[lang];
+
   const name = formData.get("name")?.toString().trim() ?? "";
   const email = formData.get("email")?.toString().trim().toLowerCase() ?? "";
   const message = formData.get("message")?.toString().trim() ?? "";
 
-  const err = validate(name, email, message);
+  const err = validate(name, email, message, m);
   if (err) return { success: false, error: err };
 
   if (!process.env.RESEND_API_KEY) {
     console.warn("RESEND_API_KEY is not set");
-    return { success: false, error: "Email service not configured." };
+    return { success: false, error: m.service_error };
   }
 
   const from = "DuxPace Contact <onboarding@resend.dev>";
@@ -52,7 +86,7 @@ export async function sendContactEmail(
 
   if (error) {
     console.error("Resend error:", error);
-    return { success: false, error: "Failed to send. Please try again." };
+    return { success: false, error: m.send_failed };
   }
 
   return { success: true };

--- a/app/features/home/components/Contact.tsx
+++ b/app/features/home/components/Contact.tsx
@@ -9,7 +9,7 @@ import { sendContactEmail } from "../../../actions/contact";
 import { motion } from "framer-motion";
 
 function ContactForm({ onReset }: { onReset: () => void }) {
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
   const [state, action, pending] = useActionState(sendContactEmail, null);
   const [formData, setFormData] = useState({ name: "", email: "", message: "" });
 
@@ -44,6 +44,7 @@ function ContactForm({ onReset }: { onReset: () => void }) {
 
   return (
     <form action={action} className="space-y-5">
+      <input type="hidden" name="lang" value={lang} />
       <div>
         <label htmlFor="contact-name" className="block text-xs text-gray-400 mb-1.5">
           {t.contact.nameLabel}


### PR DESCRIPTION
Contact form validation errors were always returned in English, even when the user switched the site to Norwegian. The server action had no way to know the user's language preference because it lives in client-side localStorage. This adds a hidden `lang` field to the form so the server action receives the user's language on each submission, and adds Norwegian translations for all validation and send-failure messages.