### PR TITLE
fix: eliminate language flash by reading localStorage before first paint (closes #30)

### DIFF
--- a/app/shared/components/HtmlLang.tsx
+++ b/app/shared/components/HtmlLang.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { useLanguage } from "../providers/LanguageProvider";
 
 export default function HtmlLang() {
   const { lang } = useLanguage();
-  useEffect(() => {
+  useLayoutEffect(() => {
     document.documentElement.lang = lang;
   }, [lang]);
   return null;

--- a/app/shared/components/HtmlLang.tsx
+++ b/app/shared/components/HtmlLang.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { useLanguage } from "../providers/LanguageProvider";
+
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export default function HtmlLang() {
   const { lang } = useLanguage();
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     document.documentElement.lang = lang;
   }, [lang]);
   return null;

--- a/app/shared/providers/LanguageProvider.tsx
+++ b/app/shared/providers/LanguageProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useLayoutEffect, useState } from "react";
 import { translations, type Language } from "../../lib/data/content";
 
 type LanguageContextType = {
@@ -15,11 +15,11 @@ const LanguageContext = createContext<LanguageContextType | null>(null);
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const [lang, setLangState] = useState<Language>("en");
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const saved = localStorage.getItem("lang") as Language | null;
     if (saved === "en" || saved === "no") {
-      // Use requestAnimationFrame to avoid synchronous setState in effect
-      requestAnimationFrame(() => setLangState(saved));
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLangState(saved);
     }
   }, []);
 

--- a/app/shared/providers/LanguageProvider.tsx
+++ b/app/shared/providers/LanguageProvider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { createContext, useContext, useLayoutEffect, useState } from "react";
+import { createContext, useContext, useEffect, useLayoutEffect, useState } from "react";
 import { translations, type Language } from "../../lib/data/content";
+
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 type LanguageContextType = {
   lang: Language;
@@ -15,10 +17,9 @@ const LanguageContext = createContext<LanguageContextType | null>(null);
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const [lang, setLangState] = useState<Language>("en");
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const saved = localStorage.getItem("lang") as Language | null;
     if (saved === "en" || saved === "no") {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setLangState(saved);
     }
   }, []);


### PR DESCRIPTION
Returning Norwegian users saw the entire page render in English for one to two frames on every page load because LanguageProvider read localStorage in a useEffect wrapped in requestAnimationFrame, which fires well after the browser has painted. Replacing both with useLayoutEffect and a direct setState call applies the saved language synchronously after hydration and before the first paint, so Norwegian content is correct from the first frame the user sees. The same fix is applied to HtmlLang so the html lang attribute is also set before paint.