### PR TITLE
fix: respect prefers-reduced-motion in all framer-motion animations (closes #32)

### DIFF
--- a/app/features/home/components/Contact.tsx
+++ b/app/features/home/components/Contact.tsx
@@ -6,7 +6,7 @@ import { DramaticCard } from "../../../shared/components/ui/HoverEffects";
 import { useLanguage } from "../../../shared/providers/LanguageProvider";
 import { siteConfig } from "../../../lib/data/content";
 import { sendContactEmail } from "../../../actions/contact";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 
 function ContactForm({ onReset }: { onReset: () => void }) {
   const { t, lang } = useLanguage();
@@ -128,21 +128,15 @@ export default function Contact() {
   const { t } = useLanguage();
   const { email, location, mapEmbed } = siteConfig.contact;
   const [formKey, setFormKey] = useState(0);
+  const shouldReduce = useReducedMotion();
 
   return (
     <section id="contact" className="py-28 md:py-40 border-t border-white/[0.07] relative overflow-hidden">
       {/* Background effects */}
       <motion.div
         className="absolute bottom-0 left-1/4 w-[600px] h-[600px] bg-blue-500/10 rounded-full blur-3xl pointer-events-none"
-        animate={{
-          scale: [1, 1.2, 1],
-          opacity: [0.2, 0.3, 0.2],
-        }}
-        transition={{
-          duration: 8,
-          repeat: Infinity,
-          ease: "easeInOut",
-        }}
+        animate={shouldReduce ? { opacity: 0.2 } : { scale: [1, 1.2, 1], opacity: [0.2, 0.3, 0.2] }}
+        transition={shouldReduce ? {} : { duration: 8, repeat: Infinity, ease: "easeInOut" }}
       />
       
       <div className="max-w-7xl mx-auto px-6 relative">

--- a/app/features/home/components/Contact.tsx
+++ b/app/features/home/components/Contact.tsx
@@ -135,6 +135,7 @@ export default function Contact() {
       {/* Background effects */}
       <motion.div
         className="absolute bottom-0 left-1/4 w-[600px] h-[600px] bg-blue-500/10 rounded-full blur-3xl pointer-events-none"
+        initial={shouldReduce ? { opacity: 0.2 } : false}
         animate={shouldReduce ? { opacity: 0.2 } : { scale: [1, 1.2, 1], opacity: [0.2, 0.3, 0.2] }}
         transition={shouldReduce ? {} : { duration: 8, repeat: Infinity, ease: "easeInOut" }}
       />

--- a/app/features/home/components/Hero.tsx
+++ b/app/features/home/components/Hero.tsx
@@ -2,20 +2,22 @@
 
 import GlobeWrapper from "../../../shared/components/GlobeWrapper";
 import { useLanguage } from "../../../shared/providers/LanguageProvider";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 
 const ease = [0.16, 1, 0.3, 1] as const;
 
-function fadeUp(delay: number) {
-  return {
-    initial: { opacity: 0, y: 24 },
-    animate: { opacity: 1, y: 0 },
-    transition: { delay, duration: 0.4, ease },
-  };
-}
-
 export default function Hero() {
   const { t } = useLanguage();
+  const shouldReduce = useReducedMotion();
+
+  function fadeUp(delay: number) {
+    if (shouldReduce) return {};
+    return {
+      initial: { opacity: 0, y: 24 },
+      animate: { opacity: 1, y: 0 },
+      transition: { delay, duration: 0.4, ease },
+    };
+  }
 
   return (
     <section id="home" className="relative min-h-svh flex items-center overflow-hidden">

--- a/app/features/home/components/News.tsx
+++ b/app/features/home/components/News.tsx
@@ -6,7 +6,7 @@ import { FadeIn } from "../../../shared/components/animations/ScrollReveal";
 import { useLanguage } from "../../../shared/providers/LanguageProvider";
 import { newsItems, localize, type NewsItem } from "../../../lib/data/news";
 import { useState, useEffect } from "react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 
 const PER_PAGE = 3;
@@ -28,7 +28,8 @@ const NewsCard = memo(function NewsCard({
   lang: "en" | "no";
 }) {
   const { title, description, date } = localize(item, lang);
-  
+  const shouldReduce = useReducedMotion();
+
   const handleClick = useCallback(() => {
     onClick(globalIndex);
   }, [onClick, globalIndex]);
@@ -72,8 +73,8 @@ const NewsCard = memo(function NewsCard({
               {t.news.readMore}
               <motion.span
                 className="inline-block"
-                animate={{ x: [0, 3, 0] }}
-                transition={{ duration: 1.5, repeat: Infinity }}
+                animate={shouldReduce ? {} : { x: [0, 3, 0] }}
+                transition={shouldReduce ? {} : { duration: 1.5, repeat: Infinity }}
               >
                 →
               </motion.span>
@@ -92,6 +93,7 @@ export default function News() {
   const searchParams = useSearchParams();
   const [page, setPage] = useState(0);
   const [selected, setSelected] = useState<number | null>(null);
+  const shouldReduce = useReducedMotion();
 
   const totalPages = Math.ceil(newsItems.length / PER_PAGE);
   const visibleItems = newsItems.slice(page * PER_PAGE, page * PER_PAGE + PER_PAGE);
@@ -141,15 +143,8 @@ export default function News() {
       {/* Background glow */}
       <motion.div
         className="absolute top-0 right-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl"
-        animate={{
-          y: [0, 50, 0],
-          opacity: [0.2, 0.4, 0.2],
-        }}
-        transition={{
-          duration: 6,
-          repeat: Infinity,
-          ease: "easeInOut",
-        }}
+        animate={shouldReduce ? { opacity: 0.2 } : { y: [0, 50, 0], opacity: [0.2, 0.4, 0.2] }}
+        transition={shouldReduce ? {} : { duration: 6, repeat: Infinity, ease: "easeInOut" }}
       />
       
       <div className="max-w-7xl mx-auto px-6 relative">

--- a/app/features/home/components/News.tsx
+++ b/app/features/home/components/News.tsx
@@ -143,6 +143,7 @@ export default function News() {
       {/* Background glow */}
       <motion.div
         className="absolute top-0 right-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl"
+        initial={shouldReduce ? { opacity: 0.2 } : false}
         animate={shouldReduce ? { opacity: 0.2 } : { y: [0, 50, 0], opacity: [0.2, 0.4, 0.2] }}
         transition={shouldReduce ? {} : { duration: 6, repeat: Infinity, ease: "easeInOut" }}
       />

--- a/app/shared/components/animations/ScrollReveal.tsx
+++ b/app/shared/components/animations/ScrollReveal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, ReactNode } from "react";
-import { motion, useInView } from "framer-motion";
+import { motion, useInView, useReducedMotion } from "framer-motion";
 
 export function useScrollReveal(threshold = 0.2, once = true) {
   const ref = useRef<HTMLDivElement>(null);
@@ -27,6 +27,7 @@ export function FadeIn({
   distance = 30,
 }: FadeInProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
 
   const directions = {
     up: { y: distance, x: 0 },
@@ -40,13 +41,9 @@ export function FadeIn({
     <motion.div
       ref={ref}
       className={className}
-      initial={{ opacity: 0, ...directions[direction] }}
-      animate={isInView ? { opacity: 1, y: 0, x: 0 } : {}}
-      transition={{
-        duration,
-        delay,
-        ease: [0.25, 0.1, 0.25, 1],
-      }}
+      initial={shouldReduce ? false : { opacity: 0, ...directions[direction] }}
+      animate={shouldReduce ? {} : (isInView ? { opacity: 1, y: 0, x: 0 } : {})}
+      transition={shouldReduce ? {} : { duration, delay, ease: [0.25, 0.1, 0.25, 1] }}
     >
       {children}
     </motion.div>
@@ -67,18 +64,15 @@ export function ScaleIn({
   duration = 0.5,
 }: ScaleInProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
 
   return (
     <motion.div
       ref={ref}
       className={className}
-      initial={{ opacity: 0, scale: 0.9 }}
-      animate={isInView ? { opacity: 1, scale: 1 } : {}}
-      transition={{
-        duration,
-        delay,
-        ease: [0.25, 0.1, 0.25, 1],
-      }}
+      initial={shouldReduce ? false : { opacity: 0, scale: 0.9 }}
+      animate={shouldReduce ? {} : (isInView ? { opacity: 1, scale: 1 } : {})}
+      transition={shouldReduce ? {} : { duration, delay, ease: [0.25, 0.1, 0.25, 1] }}
     >
       {children}
     </motion.div>
@@ -99,14 +93,15 @@ export function Stagger({
   baseDelay = 0,
 }: StaggerProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
 
   return (
     <motion.div
       ref={ref}
       className={className}
-      initial="hidden"
-      animate={isInView ? "visible" : "hidden"}
-      variants={{
+      initial={shouldReduce ? false : "hidden"}
+      animate={shouldReduce ? "visible" : (isInView ? "visible" : "hidden")}
+      variants={shouldReduce ? undefined : {
         hidden: {},
         visible: {
           transition: {
@@ -128,10 +123,12 @@ export function StaggerItem({
   children: ReactNode;
   className?: string;
 }) {
+  const shouldReduce = useReducedMotion();
+
   return (
     <motion.div
       className={className}
-      variants={{
+      variants={shouldReduce ? {} : {
         hidden: { opacity: 0, y: 20 },
         visible: {
           opacity: 1,
@@ -162,22 +159,19 @@ export function LineReveal({
   duration = 0.8,
 }: LineRevealProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
   const isHorizontal = direction === "horizontal";
 
   return (
     <motion.div
       ref={ref}
       className={`bg-white/20 ${isHorizontal ? "h-px" : "w-px"} ${className}`}
-      initial={{
+      initial={shouldReduce ? false : {
         scaleX: isHorizontal ? 0 : 1,
         scaleY: isHorizontal ? 1 : 0,
       }}
-      animate={isInView ? { scaleX: 1, scaleY: 1 } : {}}
-      transition={{
-        duration,
-        delay,
-        ease: [0.25, 0.1, 0.25, 1],
-      }}
+      animate={shouldReduce ? {} : (isInView ? { scaleX: 1, scaleY: 1 } : {})}
+      transition={shouldReduce ? {} : { duration, delay, ease: [0.25, 0.1, 0.25, 1] }}
       style={{
         originX: isHorizontal ? 0 : 0.5,
         originY: isHorizontal ? 0.5 : 0,
@@ -200,6 +194,7 @@ export function ImageFade({
   delay = 0,
 }: ImageFadeProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
 
   return (
     <motion.div ref={ref} className={`overflow-hidden ${className}`}>
@@ -207,9 +202,9 @@ export function ImageFade({
         src={src}
         alt={alt}
         className="w-full h-full object-cover"
-        initial={{ opacity: 0, scale: 1.1 }}
-        animate={isInView ? { opacity: 1, scale: 1 } : {}}
-        transition={{
+        initial={shouldReduce ? false : { opacity: 0, scale: 1.1 }}
+        animate={shouldReduce ? {} : (isInView ? { opacity: 1, scale: 1 } : {})}
+        transition={shouldReduce ? {} : {
           opacity: { duration: 0.6, delay },
           scale: { duration: 0.8, delay },
           ease: [0.25, 0.1, 0.25, 1],
@@ -232,6 +227,7 @@ export function TextReveal({
   delay = 0,
 }: TextRevealProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
   const words = children.split(" ");
 
   return (
@@ -240,9 +236,9 @@ export function TextReveal({
         <motion.span
           key={index}
           className="inline-block mr-[0.25em]"
-          initial={{ opacity: 0, y: 10 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{
+          initial={shouldReduce ? false : { opacity: 0, y: 10 }}
+          animate={shouldReduce ? {} : (isInView ? { opacity: 1, y: 0 } : {})}
+          transition={shouldReduce ? {} : {
             duration: 0.4,
             delay: delay + index * 0.05,
             ease: [0.25, 0.1, 0.25, 1],
@@ -268,21 +264,22 @@ export function AnimatedBorder({
   delay = 0,
 }: AnimatedBorderProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
 
   return (
     <motion.div
       ref={ref}
       className={`relative ${className}`}
-      initial={{ opacity: 0 }}
-      animate={isInView ? { opacity: 1 } : {}}
-      transition={{ duration: 0.4, delay }}
+      initial={shouldReduce ? false : { opacity: 0 }}
+      animate={shouldReduce ? {} : (isInView ? { opacity: 1 } : {})}
+      transition={shouldReduce ? {} : { duration: 0.4, delay }}
     >
       {children}
       <motion.div
         className="absolute inset-0 border border-white/10 rounded-lg pointer-events-none"
-        initial={{ opacity: 0, scale: 0.95 }}
-        animate={isInView ? { opacity: 1, scale: 1 } : {}}
-        transition={{
+        initial={shouldReduce ? false : { opacity: 0, scale: 0.95 }}
+        animate={shouldReduce ? {} : (isInView ? { opacity: 1, scale: 1 } : {})}
+        transition={shouldReduce ? {} : {
           duration: 0.5,
           delay: delay + 0.2,
           ease: [0.25, 0.1, 0.25, 1],
@@ -307,22 +304,15 @@ export function BlurIn({
   duration = 0.6,
 }: BlurInProps) {
   const { ref, isInView } = useScrollReveal();
+  const shouldReduce = useReducedMotion();
 
   return (
     <motion.div
       ref={ref}
       className={className}
-      initial={{ opacity: 0, filter: "blur(10px)" }}
-      animate={
-        isInView
-          ? { opacity: 1, filter: "blur(0px)" }
-          : {}
-      }
-      transition={{
-        duration,
-        delay,
-        ease: [0.25, 0.1, 0.25, 1],
-      }}
+      initial={shouldReduce ? false : { opacity: 0, filter: "blur(10px)" }}
+      animate={shouldReduce ? {} : (isInView ? { opacity: 1, filter: "blur(0px)" } : {})}
+      transition={shouldReduce ? {} : { duration, delay, ease: [0.25, 0.1, 0.25, 1] }}
     >
       {children}
     </motion.div>


### PR DESCRIPTION
The CSS `@media (prefers-reduced-motion: reduce)` rule in globals.css only silences CSS animations and transitions, not Framer Motion JS-driven animations which apply transforms via inline styles. All ScrollReveal components (FadeIn, ScaleIn, Stagger, StaggerItem, TextReveal, LineReveal, ImageFade, AnimatedBorder, BlurIn), the Hero page-load animations, and the infinite background pulse animations in News and Contact all animated unconditionally. Added `useReducedMotion()` from Framer Motion to each component: scroll-reveal animations are skipped entirely (elements render immediately visible), and infinite background animations are held static at their low-opacity resting state.