### PR TITLE
fix: add aria-labelledby, focus trap, escape key, and focus restore to news modal (closes #34)

### DIFF
--- a/app/features/home/components/News.tsx
+++ b/app/features/home/components/News.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { memo, useCallback } from "react";
+import { memo, useCallback, useRef } from "react";
 import { FadeIn } from "../../../shared/components/animations/ScrollReveal";
 import { useLanguage } from "../../../shared/providers/LanguageProvider";
 import { newsItems, localize, type NewsItem } from "../../../lib/data/news";
@@ -93,6 +93,10 @@ export default function News() {
   const [page, setPage] = useState(0);
   const [selected, setSelected] = useState<number | null>(null);
 
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
   const totalPages = Math.ceil(newsItems.length / PER_PAGE);
   const visibleItems = newsItems.slice(page * PER_PAGE, page * PER_PAGE + PER_PAGE);
 
@@ -135,6 +139,56 @@ export default function News() {
       document.body.style.overflow = "";
     };
   }, [selected]);
+
+  useEffect(() => {
+    if (selected !== null) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      closeButtonRef.current?.focus();
+    } else {
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    }
+  }, [selected]);
+
+  useEffect(() => {
+    if (selected === null) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        closeModal();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const modal = modalRef.current;
+      if (!modal) return;
+
+      const focusable = Array.from(
+        modal.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((el) => !el.hasAttribute("disabled"));
+
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [selected, closeModal]);
 
   return (
     <section id="news" className="py-28 md:py-40 border-t border-white/[0.07] relative">
@@ -232,10 +286,12 @@ export default function News() {
           <div
             role="dialog"
             aria-modal="true"
+            aria-labelledby="news-modal-title"
             className="fixed inset-0 z-50 flex items-end md:items-center justify-center bg-black/90 backdrop-blur-md p-0 md:p-6"
             onClick={closeModal}
           >
             <motion.div
+              ref={modalRef}
               className="bg-black border border-white/[0.12] w-full md:max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg"
               onClick={(e) => e.stopPropagation()}
               initial={{ opacity: 0, scale: 0.9, y: 50 }}
@@ -246,6 +302,7 @@ export default function News() {
               <div className="relative w-full aspect-video">
                 <Image src={item.image} alt={item.alt} fill className="object-cover" />
                 <motion.button
+                  ref={closeButtonRef}
                   onClick={closeModal}
                   aria-label="Close article"
                   className="absolute top-4 right-4 bg-black/70 hover:bg-blue-500 text-white w-10 h-10 flex items-center justify-center rounded-full transition-colors"
@@ -257,7 +314,7 @@ export default function News() {
               </div>
               <div className="p-8">
                 <p className="text-[10px] text-blue-400 font-mono tracking-[0.18em] uppercase mb-3">{date}</p>
-                <h2 className="text-2xl font-bold text-white mb-6 leading-snug tracking-tight">{title}</h2>
+                <h2 id="news-modal-title" className="text-2xl font-bold text-white mb-6 leading-snug tracking-tight">{title}</h2>
                 {content.split("\n\n").map((paragraph, i) => (
                   <p key={i} className="text-gray-400 text-sm leading-relaxed mb-4">{paragraph}</p>
                 ))}

--- a/app/features/home/components/News.tsx
+++ b/app/features/home/components/News.tsx
@@ -167,7 +167,7 @@ export default function News() {
         modal.querySelectorAll<HTMLElement>(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         )
-      ).filter((el) => !el.hasAttribute("disabled"));
+      ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
 
       if (focusable.length === 0) return;
       const first = focusable[0];


### PR DESCRIPTION
The news modal had role=dialog and aria-modal=true but was missing aria-labelledby, so screen readers could not identify its title. Focus was not moved into the modal on open, not trapped inside, and not restored on close, breaking keyboard navigation entirely. This adds aria-labelledby pointing to the modal h2, focuses the close button when the modal opens, restores focus to the triggering card button on close, traps Tab/Shift-Tab within the modal panel, and closes on Escape.