### PR TITLE
fix: add honeypot to contact form to block bot submissions (closes #38)

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -62,6 +62,10 @@ export async function sendContactEmail(
   const lang = formData.get("lang") === "no" ? "no" : "en";
   const m = MESSAGES[lang];
 
+  // Honeypot: bots fill this, humans don't see it
+  const honeypot = formData.get("website")?.toString() ?? "";
+  if (honeypot) return { success: true };
+
   const name = formData.get("name")?.toString().trim() ?? "";
   const email = formData.get("email")?.toString().trim().toLowerCase() ?? "";
   const message = formData.get("message")?.toString().trim() ?? "";

--- a/app/features/home/components/Contact.tsx
+++ b/app/features/home/components/Contact.tsx
@@ -45,6 +45,11 @@ function ContactForm({ onReset }: { onReset: () => void }) {
   return (
     <form action={action} className="space-y-5">
       <input type="hidden" name="lang" value={lang} />
+      {/* Honeypot: visually hidden, only bots fill this */}
+      <div aria-hidden="true" style={{ position: "absolute", left: "-9999px", width: "1px", height: "1px", overflow: "hidden" }}>
+        <label htmlFor="contact-website">Website</label>
+        <input id="contact-website" type="text" name="website" tabIndex={-1} autoComplete="off" />
+      </div>
       <div>
         <label htmlFor="contact-name" className="block text-xs text-gray-400 mb-1.5">
           {t.contact.nameLabel}


### PR DESCRIPTION
The contact form had no bot protection, allowing any script to call the server action unlimited times and exhaust the Resend email quota. A CSS-positioned honeypot field named `website` is added to the form -- invisible and unreachable to real users via absolute positioning off-screen, `tabIndex={-1}`, and `autoComplete="off"`. The server action checks this field first and silently returns success if it is filled, giving bots no signal they were caught.