### PR TITLE
add honeypot field to contact form to block bot submissions

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -59,6 +59,9 @@ export async function sendContactEmail(
   _prevState: ContactState,
   formData: FormData,
 ): Promise<ContactState> {
+  const honeypot = formData.get("website")?.toString() ?? "";
+  if (honeypot) return { success: true };
+
   const lang = formData.get("lang") === "no" ? "no" : "en";
   const m = MESSAGES[lang];
 

--- a/app/features/home/components/Contact.tsx
+++ b/app/features/home/components/Contact.tsx
@@ -45,6 +45,17 @@ function ContactForm({ onReset }: { onReset: () => void }) {
   return (
     <form action={action} className="space-y-5">
       <input type="hidden" name="lang" value={lang} />
+      {/* honeypot: hidden from real users, bots fill it */}
+      <div aria-hidden="true" style={{ position: "absolute", left: "-9999px", width: 0, height: 0, overflow: "hidden" }}>
+        <label htmlFor="contact-website">Website</label>
+        <input
+          id="contact-website"
+          type="text"
+          name="website"
+          tabIndex={-1}
+          autoComplete="off"
+        />
+      </div>
       <div>
         <label htmlFor="contact-name" className="block text-xs text-gray-400 mb-1.5">
           {t.contact.nameLabel}


### PR DESCRIPTION
Closes #38.

Adds a CSS-hidden honeypot field named "website" to the contact form. Real users never see it because it is positioned off-screen, has aria-hidden, tabIndex -1, and autoComplete off. If the field is filled on submission the server action silently returns success so bots get no signal they were caught. No UX change for legitimate users.