### PR TITLE
fix: catch Resend throws in contact server action (closes #43)

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -76,16 +76,21 @@ export async function sendContactEmail(
 
   const from = "DuxPace Contact <onboarding@resend.dev>";
 
-  const { error } = await resend.emails.send({
-    from,
-    to: "planet@duxpace.no",
-    replyTo: email,
-    subject: `New message from ${name}`,
-    text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
-  });
+  try {
+    const { error } = await resend.emails.send({
+      from,
+      to: "planet@duxpace.no",
+      replyTo: email,
+      subject: `New message from ${name}`,
+      text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+    });
 
-  if (error) {
-    console.error("Resend error:", error);
+    if (error) {
+      console.error("Resend error:", error);
+      return { success: false, error: m.send_failed };
+    }
+  } catch (err) {
+    console.error("Resend threw:", err);
     return { success: false, error: m.send_failed };
   }
 


### PR DESCRIPTION
The sendContactEmail server action awaited resend.emails.send() with no try/catch. If Resend throws rather than returning an error object (network timeout, service unreachable, or SDK constructor failure from a missing API key), the exception escaped the action and crashed through the Next.js error boundary in production. Users would see a broken page instead of the localized send_failed message, with no recovery path. This wraps the send call in try/catch and returns the proper error state in both paths.