### PR TITLE
catch resend throws in contact server action and return send_failed

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -76,16 +76,23 @@ export async function sendContactEmail(
 
   const from = "DuxPace Contact <onboarding@resend.dev>";
 
-  const { error } = await resend.emails.send({
-    from,
-    to: "planet@duxpace.no",
-    replyTo: email,
-    subject: `New message from ${name}`,
-    text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
-  });
+  let sendError: unknown;
+  try {
+    const { error } = await resend.emails.send({
+      from,
+      to: "planet@duxpace.no",
+      replyTo: email,
+      subject: `New message from ${name}`,
+      text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+    });
+    sendError = error;
+  } catch (err) {
+    console.error("Resend threw:", err);
+    return { success: false, error: m.send_failed };
+  }
 
-  if (error) {
-    console.error("Resend error:", error);
+  if (sendError) {
+    console.error("Resend error:", sendError);
     return { success: false, error: m.send_failed };
   }
 


### PR DESCRIPTION
Closes #43.

The `resend.emails.send()` call had no try/catch, so any exception thrown by the Resend SDK (network timeout, service unreachable, undefined API key on the SDK instance) escaped the server action and crashed through the Next.js error boundary. Users saw a broken page instead of the send_failed message. The send call is now wrapped in a try/catch that logs the error and returns the localized send_failed state, matching the existing behavior for Resend error objects.