### PR TITLE
add 60-second cookie-based rate limit to contact form

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { cookies } from "next/headers";
 import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -24,6 +25,7 @@ const MESSAGES = {
     message_long: "Message must be less than 5000 characters.",
     service_error: "Email service not configured.",
     send_failed: "Failed to send. Please try again.",
+    rate_limited: "Please wait 60 seconds before sending another message.",
   },
   no: {
     name_empty: "Vennligst oppgi ditt navn.",
@@ -37,6 +39,7 @@ const MESSAGES = {
     message_long: "Meldingen kan ikke være mer enn 5000 tegn.",
     service_error: "E-posttjeneste ikke konfigurert.",
     send_failed: "Sending mislyktes. Prøv igjen.",
+    rate_limited: "Vent 60 sekunder før du sender en ny melding.",
   },
 };
 
@@ -69,6 +72,11 @@ export async function sendContactEmail(
   const err = validate(name, email, message, m);
   if (err) return { success: false, error: err };
 
+  const jar = await cookies();
+  if (jar.get("contact_rl")) {
+    return { success: false, error: m.rate_limited };
+  }
+
   if (!process.env.RESEND_API_KEY) {
     console.warn("RESEND_API_KEY is not set");
     return { success: false, error: m.service_error };
@@ -95,6 +103,13 @@ export async function sendContactEmail(
     console.error("Resend error:", sendError);
     return { success: false, error: m.send_failed };
   }
+
+  jar.set("contact_rl", "1", {
+    httpOnly: true,
+    sameSite: "strict",
+    path: "/",
+    maxAge: 60,
+  });
 
   return { success: true };
 }

--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -1,12 +1,12 @@
 "use server";
 
-import { headers } from "next/headers";
+import { cookies } from "next/headers";
 import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const RL_WINDOW_MS = 60_000;
-const rateLimitStore = new Map<string, number>();
+const RL_COOKIE = "rl_contact";
+const RL_WINDOW_S = 60;
 
 export type ContactState = {
   success: boolean;
@@ -75,14 +75,8 @@ export async function sendContactEmail(
   const err = validate(name, email, message, m);
   if (err) return { success: false, error: err };
 
-  const hdrs = await headers();
-  const ip =
-    hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    hdrs.get("x-real-ip") ??
-    "unknown";
-  const now = Date.now();
-  const last = rateLimitStore.get(ip);
-  if (last !== undefined && now - last < RL_WINDOW_MS) {
+  const cookieStore = await cookies();
+  if (cookieStore.get(RL_COOKIE)) {
     return { success: false, error: m.rate_limited };
   }
 
@@ -113,7 +107,13 @@ export async function sendContactEmail(
     return { success: false, error: m.send_failed };
   }
 
-  rateLimitStore.set(ip, now);
+  (await cookies()).set(RL_COOKIE, "1", {
+    maxAge: RL_WINDOW_S,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    path: "/",
+  });
 
   return { success: true };
 }

--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -1,9 +1,12 @@
 "use server";
 
-import { cookies } from "next/headers";
+import { headers } from "next/headers";
 import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
+
+const RL_WINDOW_MS = 60_000;
+const rateLimitStore = new Map<string, number>();
 
 export type ContactState = {
   success: boolean;
@@ -72,8 +75,14 @@ export async function sendContactEmail(
   const err = validate(name, email, message, m);
   if (err) return { success: false, error: err };
 
-  const jar = await cookies();
-  if (jar.get("contact_rl")) {
+  const hdrs = await headers();
+  const ip =
+    hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    hdrs.get("x-real-ip") ??
+    "unknown";
+  const now = Date.now();
+  const last = rateLimitStore.get(ip);
+  if (last !== undefined && now - last < RL_WINDOW_MS) {
     return { success: false, error: m.rate_limited };
   }
 
@@ -104,13 +113,7 @@ export async function sendContactEmail(
     return { success: false, error: m.send_failed };
   }
 
-  jar.set("contact_rl", "1", {
-    httpOnly: true,
-    secure: true,
-    sameSite: "strict",
-    path: "/",
-    maxAge: 60,
-  });
+  rateLimitStore.set(ip, now);
 
   return { success: true };
 }

--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -106,6 +106,7 @@ export async function sendContactEmail(
 
   jar.set("contact_rl", "1", {
     httpOnly: true,
+    secure: true,
     sameSite: "strict",
     path: "/",
     maxAge: 60,


### PR DESCRIPTION
Closes #41.

After a successful submission, the server action now sets a `contact_rl` cookie with a 60-second `maxAge`. Any subsequent call within that window is rejected before reaching Resend, with a localized error message in both English and Norwegian. No new dependencies; uses `cookies()` from `next/headers` which is already available in the Next.js app.