### PR TITLE
fix: log errors in sanity query catch blocks (closes #47)

### DIFF
--- a/app/_lib/sanity.ts
+++ b/app/_lib/sanity.ts
@@ -9,6 +9,7 @@ import {
   NewsArticle,
   ContactSection,
 } from "@/types/sanity";
+import { logger } from "./logger";
 
 // Lazy initialization - only create client when needed
 let clientInstance: SanityClient | null = null;
@@ -89,7 +90,8 @@ export async function getSiteSettings(): Promise<SiteSettings | null> {
   try {
     const query = `*[_type == "siteSettings"][0]`;
     return (await client.fetch(query)) || null;
-  } catch {
+  } catch (err) {
+    logger.error("getSiteSettings failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }
@@ -98,7 +100,8 @@ export async function getHeroSection(): Promise<HeroSection | null> {
   try {
     const query = `*[_type == "heroSection"][0]`;
     return (await client.fetch(query)) || null;
-  } catch {
+  } catch (err) {
+    logger.error("getHeroSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }
@@ -107,7 +110,8 @@ export async function getAboutSection(): Promise<AboutSection | null> {
   try {
     const query = `*[_type == "aboutSection"][0]`;
     return (await client.fetch(query)) || null;
-  } catch {
+  } catch (err) {
+    logger.error("getAboutSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }
@@ -118,7 +122,8 @@ export async function getTeamMembers(): Promise<TeamMember[]> {
       _id, name, role, image, bio, linkedin, order
     }`;
     return (await client.fetch(query)) || [];
-  } catch {
+  } catch (err) {
+    logger.error("getTeamMembers failed", err instanceof Error ? err : new Error(String(err)));
     return [];
   }
 }
@@ -130,7 +135,8 @@ export async function getNewsArticles(limit?: number): Promise<NewsArticle[]> {
       _id, title, slug, excerpt, image, publishedAt, featured
     }`;
     return (await client.fetch(query)) || [];
-  } catch {
+  } catch (err) {
+    logger.error("getNewsArticles failed", err instanceof Error ? err : new Error(String(err)));
     return [];
   }
 }
@@ -139,7 +145,8 @@ export async function getNewsArticleBySlug(slug: string): Promise<NewsArticle | 
   try {
     const query = `*[_type == "newsArticle" && slug.current == $slug][0]`;
     return (await client.fetch(query, { slug })) || null;
-  } catch {
+  } catch (err) {
+    logger.error("getNewsArticleBySlug failed", err instanceof Error ? err : new Error(String(err)), { slug });
     return null;
   }
 }
@@ -148,7 +155,8 @@ export async function getContactSection(): Promise<ContactSection | null> {
   try {
     const query = `*[_type == "contactSection"][0]`;
     return (await client.fetch(query)) || null;
-  } catch {
+  } catch (err) {
+    logger.error("getContactSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }

--- a/app/_lib/sanity.ts
+++ b/app/_lib/sanity.ts
@@ -11,6 +11,15 @@ import {
 } from "@/types/sanity";
 import { logger } from "./logger";
 
+function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  try {
+    return new Error(JSON.stringify(err));
+  } catch {
+    return new Error(String(err));
+  }
+}
+
 // Lazy initialization - only create client when needed
 let clientInstance: SanityClient | null = null;
 let builderInstance: ReturnType<typeof import("@sanity/image-url").default> | null = null;
@@ -91,7 +100,7 @@ export async function getSiteSettings(): Promise<SiteSettings | null> {
     const query = `*[_type == "siteSettings"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getSiteSettings failed", err instanceof Error ? err : new Error(String(err)));
+    try { logger.error("getSiteSettings failed", toError(err)); } catch { /* ignore */ }
     return null;
   }
 }
@@ -101,7 +110,7 @@ export async function getHeroSection(): Promise<HeroSection | null> {
     const query = `*[_type == "heroSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getHeroSection failed", err instanceof Error ? err : new Error(String(err)));
+    try { logger.error("getHeroSection failed", toError(err)); } catch { /* ignore */ }
     return null;
   }
 }
@@ -111,7 +120,7 @@ export async function getAboutSection(): Promise<AboutSection | null> {
     const query = `*[_type == "aboutSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getAboutSection failed", err instanceof Error ? err : new Error(String(err)));
+    try { logger.error("getAboutSection failed", toError(err)); } catch { /* ignore */ }
     return null;
   }
 }
@@ -123,7 +132,7 @@ export async function getTeamMembers(): Promise<TeamMember[]> {
     }`;
     return (await client.fetch(query)) || [];
   } catch (err) {
-    logger.error("getTeamMembers failed", err instanceof Error ? err : new Error(String(err)));
+    try { logger.error("getTeamMembers failed", toError(err)); } catch { /* ignore */ }
     return [];
   }
 }
@@ -136,7 +145,7 @@ export async function getNewsArticles(limit?: number): Promise<NewsArticle[]> {
     }`;
     return (await client.fetch(query)) || [];
   } catch (err) {
-    logger.error("getNewsArticles failed", err instanceof Error ? err : new Error(String(err)), { limit });
+    try { logger.error("getNewsArticles failed", toError(err), { limit }); } catch { /* ignore */ }
     return [];
   }
 }
@@ -146,7 +155,7 @@ export async function getNewsArticleBySlug(slug: string): Promise<NewsArticle | 
     const query = `*[_type == "newsArticle" && slug.current == $slug][0]`;
     return (await client.fetch(query, { slug })) || null;
   } catch (err) {
-    logger.error("getNewsArticleBySlug failed", err instanceof Error ? err : new Error(String(err)), { slug });
+    try { logger.error("getNewsArticleBySlug failed", toError(err), { slug }); } catch { /* ignore */ }
     return null;
   }
 }
@@ -156,7 +165,7 @@ export async function getContactSection(): Promise<ContactSection | null> {
     const query = `*[_type == "contactSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getContactSection failed", err instanceof Error ? err : new Error(String(err)));
+    try { logger.error("getContactSection failed", toError(err)); } catch { /* ignore */ }
     return null;
   }
 }

--- a/app/_lib/sanity.ts
+++ b/app/_lib/sanity.ts
@@ -91,7 +91,7 @@ export async function getSiteSettings(): Promise<SiteSettings | null> {
     const query = `*[_type == "siteSettings"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getSiteSettings failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
+    logger.error("getSiteSettings failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }
@@ -101,7 +101,7 @@ export async function getHeroSection(): Promise<HeroSection | null> {
     const query = `*[_type == "heroSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getHeroSection failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
+    logger.error("getHeroSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }
@@ -111,7 +111,7 @@ export async function getAboutSection(): Promise<AboutSection | null> {
     const query = `*[_type == "aboutSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getAboutSection failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
+    logger.error("getAboutSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }
@@ -123,7 +123,7 @@ export async function getTeamMembers(): Promise<TeamMember[]> {
     }`;
     return (await client.fetch(query)) || [];
   } catch (err) {
-    logger.error("getTeamMembers failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
+    logger.error("getTeamMembers failed", err instanceof Error ? err : new Error(String(err)));
     return [];
   }
 }
@@ -136,7 +136,7 @@ export async function getNewsArticles(limit?: number): Promise<NewsArticle[]> {
     }`;
     return (await client.fetch(query)) || [];
   } catch (err) {
-    logger.error("getNewsArticles failed", err instanceof Error ? err : new Error(JSON.stringify(err)), { limit });
+    logger.error("getNewsArticles failed", err instanceof Error ? err : new Error(String(err)), { limit });
     return [];
   }
 }
@@ -146,7 +146,7 @@ export async function getNewsArticleBySlug(slug: string): Promise<NewsArticle | 
     const query = `*[_type == "newsArticle" && slug.current == $slug][0]`;
     return (await client.fetch(query, { slug })) || null;
   } catch (err) {
-    logger.error("getNewsArticleBySlug failed", err instanceof Error ? err : new Error(JSON.stringify(err)), { slug });
+    logger.error("getNewsArticleBySlug failed", err instanceof Error ? err : new Error(String(err)), { slug });
     return null;
   }
 }
@@ -156,7 +156,7 @@ export async function getContactSection(): Promise<ContactSection | null> {
     const query = `*[_type == "contactSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getContactSection failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
+    logger.error("getContactSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }

--- a/app/_lib/sanity.ts
+++ b/app/_lib/sanity.ts
@@ -91,7 +91,7 @@ export async function getSiteSettings(): Promise<SiteSettings | null> {
     const query = `*[_type == "siteSettings"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getSiteSettings failed", err instanceof Error ? err : new Error(String(err)));
+    logger.error("getSiteSettings failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
     return null;
   }
 }
@@ -101,7 +101,7 @@ export async function getHeroSection(): Promise<HeroSection | null> {
     const query = `*[_type == "heroSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getHeroSection failed", err instanceof Error ? err : new Error(String(err)));
+    logger.error("getHeroSection failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
     return null;
   }
 }
@@ -111,7 +111,7 @@ export async function getAboutSection(): Promise<AboutSection | null> {
     const query = `*[_type == "aboutSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getAboutSection failed", err instanceof Error ? err : new Error(String(err)));
+    logger.error("getAboutSection failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
     return null;
   }
 }
@@ -123,7 +123,7 @@ export async function getTeamMembers(): Promise<TeamMember[]> {
     }`;
     return (await client.fetch(query)) || [];
   } catch (err) {
-    logger.error("getTeamMembers failed", err instanceof Error ? err : new Error(String(err)));
+    logger.error("getTeamMembers failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
     return [];
   }
 }
@@ -136,7 +136,7 @@ export async function getNewsArticles(limit?: number): Promise<NewsArticle[]> {
     }`;
     return (await client.fetch(query)) || [];
   } catch (err) {
-    logger.error("getNewsArticles failed", err instanceof Error ? err : new Error(String(err)));
+    logger.error("getNewsArticles failed", err instanceof Error ? err : new Error(JSON.stringify(err)), { limit });
     return [];
   }
 }
@@ -146,7 +146,7 @@ export async function getNewsArticleBySlug(slug: string): Promise<NewsArticle | 
     const query = `*[_type == "newsArticle" && slug.current == $slug][0]`;
     return (await client.fetch(query, { slug })) || null;
   } catch (err) {
-    logger.error("getNewsArticleBySlug failed", err instanceof Error ? err : new Error(String(err)), { slug });
+    logger.error("getNewsArticleBySlug failed", err instanceof Error ? err : new Error(JSON.stringify(err)), { slug });
     return null;
   }
 }
@@ -156,7 +156,7 @@ export async function getContactSection(): Promise<ContactSection | null> {
     const query = `*[_type == "contactSection"][0]`;
     return (await client.fetch(query)) || null;
   } catch (err) {
-    logger.error("getContactSection failed", err instanceof Error ? err : new Error(String(err)));
+    logger.error("getContactSection failed", err instanceof Error ? err : new Error(JSON.stringify(err)));
     return null;
   }
 }


### PR DESCRIPTION
All 7 Sanity data-fetching functions in app/_lib/sanity.ts were silently swallowing errors and returning null or empty arrays with no trace. A structured logger already existed at app/_lib/logger.ts but was never imported or used anywhere in the codebase. Each catch block now calls logger.error with the function name and the caught error, so Sanity failures produce server-side logs that make production incidents diagnosable.