### PR TITLE
fix: footer copyright renders duplicate year and symbol (closes #52)

### DIFF
--- a/app/lib/data/content.ts
+++ b/app/lib/data/content.ts
@@ -15,7 +15,7 @@ export const siteConfig = {
   },
   footer: {
     logo: "/images/logos/logo-square.jpeg",
-    copyright: "© 2026 DuxPace",
+    copyright: "DuxPace",
   },
 };
 


### PR DESCRIPTION
The footer displayed "© 2026 © 2026 DuxPace" because Footer.tsx prefixes copyright with "© {currentYear}" while siteConfig.footer.copyright already contained "© 2026 DuxPace". Stripped the symbol and year from the config value so it holds only the company name, letting the JSX own the formatting. The year now tracks dynamically from new Date().getFullYear() as intended.