### PR TITLE
fix: serve correct html lang attribute from SSR using cookie

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata, Viewport } from "next";
 import { Geist } from "next/font/google";
+import { cookies } from "next/headers";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { translations } from "./lib/data/content";
+import { translations, type Language } from "./lib/data/content";
 import { LanguageProvider } from "./shared/providers/LanguageProvider";
 import { ScrollProgressIndicator } from "./shared/components/animations/SmoothScroll";
 import HtmlLang from "./shared/components/HtmlLang";
@@ -71,11 +72,15 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
+  const cookieStore = await cookies();
+  const rawLang = cookieStore.get("lang")?.value;
+  const initialLang: Language = rawLang === "en" || rawLang === "no" ? rawLang : "en";
+
   return (
-    <html lang="en" className={`scroll-smooth ${geist.variable}`}>
+    <html lang={initialLang} className={`scroll-smooth ${geist.variable}`}>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
@@ -86,7 +91,7 @@ export default function RootLayout({
         <link rel="preload" href="/images/logos/logo-wide.jpeg" as="image" />
       </head>
       <body className={`${geist.className} antialiased`}>
-        <LanguageProvider>
+        <LanguageProvider initialLang={initialLang}>
           <HtmlLang />
           <ScrollProgressIndicator />
           {children}

--- a/app/shared/providers/LanguageProvider.tsx
+++ b/app/shared/providers/LanguageProvider.tsx
@@ -5,6 +5,12 @@ import { translations, type Language } from "../../lib/data/content";
 
 const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
+const LANG_COOKIE_MAX_AGE = 365 * 24 * 60 * 60;
+
+function writeLangCookie(value: Language) {
+  document.cookie = `lang=${value}; path=/; max-age=${LANG_COOKIE_MAX_AGE}; SameSite=Lax`;
+}
+
 type LanguageContextType = {
   lang: Language;
   t: (typeof translations)[Language];
@@ -14,19 +20,27 @@ type LanguageContextType = {
 
 const LanguageContext = createContext<LanguageContextType | null>(null);
 
-export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [lang, setLangState] = useState<Language>("en");
+export function LanguageProvider({
+  children,
+  initialLang = "en",
+}: {
+  children: React.ReactNode;
+  initialLang?: Language;
+}) {
+  const [lang, setLangState] = useState<Language>(initialLang);
 
   useIsomorphicLayoutEffect(() => {
     const saved = localStorage.getItem("lang") as Language | null;
     if (saved === "en" || saved === "no") {
       setLangState(saved);
+      writeLangCookie(saved);
     }
   }, []);
 
   const setLang = (next: Language) => {
     setLangState(next);
     localStorage.setItem("lang", next);
+    writeLangCookie(next);
   };
 
   const toggle = () => setLang(lang === "en" ? "no" : "en");


### PR DESCRIPTION
Closes #55.

The html lang attribute was hardcoded as "en" in layout.tsx, so Norwegian users received incorrect pronunciation from screen readers and crawlers indexed the page as English regardless of the user's selected language.

The fix reads a "lang" cookie server-side in RootLayout and uses it for both the html lang attribute and as the initial state passed to LanguageProvider, preventing hydration mismatches. LanguageProvider now writes the cookie whenever the language is set or synced from localStorage, so the preference persists across requests.