### PR TITLE
fix: send contact form emails from noreply@duxpace.no instead of resend sandbox

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -85,7 +85,7 @@ export async function sendContactEmail(
     return { success: false, error: m.service_error };
   }
 
-  const from = "DuxPace Contact <onboarding@resend.dev>";
+  const from = "DuxPace Contact <noreply@duxpace.no>";
 
   let sendError: unknown;
   try {


### PR DESCRIPTION
Closes #56.

Changed the Resend `from` address in `app/actions/contact.ts` from `onboarding@resend.dev` (Resend's shared sandbox sender) to `noreply@duxpace.no`. The sandbox address caused emails to be flagged as spam and sent replies to Resend's test address instead of DuxPace. The Resend dashboard must have `duxpace.no` verified as a sending domain for this address to work.