### PR TITLE
add content-security-policy header via per-request nonce in proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,38 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export function proxy(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline'`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "img-src 'self' data: blob: https://unpkg.com https://images.unsplash.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    "frame-src https://www.google.com",
+    "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com",
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "upgrade-insecure-requests",
+  ].join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  response.headers.set('Content-Security-Policy', csp);
+  return response;
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
Closes #57.

Adds a Content-Security-Policy header that was previously absent. The CSP is set in a Next.js 16 `proxy.ts` file so each response gets a unique nonce — static headers in `next.config.ts` cannot do this. The `script-src` directive uses the nonce plus `'strict-dynamic'` so Vercel Analytics and Speed Insights (which inject scripts via `document.createElement`) continue to work without needing explicit origin allowlisting. External origins are restricted to only what the app actually loads: `unpkg.com` for globe textures, `google.com` for the Maps iframe, `fonts.googleapis.com`/`fonts.gstatic.com` for fonts, and `va.vercel-scripts.com`/`vitals.vercel-insights.com` for Vercel analytics.