### PR TITLE
fix: serve language-aware OG metadata and page title from cookie

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,27 +9,11 @@ import { ScrollProgressIndicator } from "./shared/components/animations/SmoothSc
 import HtmlLang from "./shared/components/HtmlLang";
 import "./globals.css";
 
-const geist = Geist({ 
+const geist = Geist({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-geist",
 });
-
-const { title, description } = translations.en.meta;
-
-const organizationJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  name: "DuxPace",
-  url: "https://duxpace.no",
-  description,
-  foundingDate: "2024-06-01",
-  location: {
-    "@type": "Place",
-    name: siteConfig.contact.location,
-  },
-  sameAs: [siteConfig.contact.linkedin],
-};
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -38,53 +22,62 @@ export const viewport: Viewport = {
   themeColor: "#000000",
 };
 
-export const metadata: Metadata = {
-  metadataBase: new URL("https://duxpace.no"),
-  title: {
-    default: title,
-    template: "%s | DuxPace",
-  },
-  description,
-  keywords: ["satellite", "aquaculture", "algal blooms", "fish farming", "Norway", "NTNU", "AI"],
-  authors: [{ name: "DuxPace" }],
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
+export async function generateMetadata(): Promise<Metadata> {
+  const cookieStore = await cookies();
+  const rawLang = cookieStore.get("lang")?.value;
+  const lang: Language = rawLang === "en" || rawLang === "no" ? rawLang : "en";
+  const { title, description } = translations[lang].meta;
+  const ogLocale = lang === "no" ? "nb_NO" : "en_US";
+
+  return {
+    metadataBase: new URL("https://duxpace.no"),
+    title: {
+      default: title,
+      template: "%s | DuxPace",
+    },
+    description,
+    keywords: ["satellite", "aquaculture", "algal blooms", "fish farming", "Norway", "NTNU", "AI"],
+    authors: [{ name: "DuxPace" }],
+    robots: {
       index: true,
       follow: true,
-      "max-video-preview": -1,
-      "max-image-preview": "large",
-      "max-snippet": -1,
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-video-preview": -1,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+      },
     },
-  },
-  icons: [
-    { rel: "icon", url: "/favicon.png", type: "image/png" },
-    { rel: "apple-touch-icon", url: "/favicon.png" },
-  ],
-  openGraph: {
-    title,
-    description,
-    url: "https://duxpace.no",
-    siteName: "DuxPace",
-    locale: "en_US",
-    type: "website",
-    images: [{ url: "/images/logos/logo-banner.jpeg", width: 1200, height: 630, alt: "DuxPace" }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-    images: ["/images/logos/logo-banner.jpeg"],
-  },
-  alternates: {
-    canonical: "https://duxpace.no",
-    languages: {
-      "en": "https://duxpace.no",
-      "no": "https://duxpace.no",
+    icons: [
+      { rel: "icon", url: "/favicon.png", type: "image/png" },
+      { rel: "apple-touch-icon", url: "/favicon.png" },
+    ],
+    openGraph: {
+      title,
+      description,
+      url: "https://duxpace.no",
+      siteName: "DuxPace",
+      locale: ogLocale,
+      alternateLocale: lang === "no" ? "en_US" : "nb_NO",
+      type: "website",
+      images: [{ url: "/images/logos/logo-banner.jpeg", width: 1200, height: 630, alt: "DuxPace" }],
     },
-  },
-};
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: ["/images/logos/logo-banner.jpeg"],
+    },
+    alternates: {
+      canonical: "https://duxpace.no",
+      languages: {
+        "en": "https://duxpace.no",
+        "no": "https://duxpace.no",
+      },
+    },
+  };
+}
 
 export default async function RootLayout({
   children,
@@ -92,6 +85,20 @@ export default async function RootLayout({
   const cookieStore = await cookies();
   const rawLang = cookieStore.get("lang")?.value;
   const initialLang: Language = rawLang === "en" || rawLang === "no" ? rawLang : "en";
+
+  const organizationJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "DuxPace",
+    url: "https://duxpace.no",
+    description: translations[initialLang].meta.description,
+    foundingDate: "2024-06-01",
+    location: {
+      "@type": "Place",
+      name: siteConfig.contact.location,
+    },
+    sameAs: [siteConfig.contact.linkedin],
+  };
 
   return (
     <html lang={initialLang} className={`scroll-smooth ${geist.variable}`}>


### PR DESCRIPTION
Closes #60.

Replaced the static `metadata` export in `app/layout.tsx` with `generateMetadata()` so the page title, description, OG tags, and Twitter cards are populated from the Norwegian or English translations depending on the visitor's `lang` cookie. The OG locale is now `nb_NO` for Norwegian visitors and `en_US` for English, with `alternateLocale` pointing to the other. The JSON-LD organization description is also language-aware now. Fixes #60.