### PR TITLE
connect sanity cms to news and team components with static data fallback

### DIFF
--- a/app/_lib/sanity.ts
+++ b/app/_lib/sanity.ts
@@ -1,7 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-
-import type { SanityClient } from "@sanity/client";
-import {
+import type {
   SiteSettings,
   HeroSection,
   AboutSection,
@@ -10,65 +7,6 @@ import {
   ContactSection,
 } from "@/types/sanity";
 import { logger } from "./logger";
-
-// Lazy initialization - only create client when needed
-let clientInstance: SanityClient | null = null;
-let builderInstance: ReturnType<typeof import("@sanity/image-url").default> | null = null;
-
-function getClient(): SanityClient {
-  if (clientInstance) return clientInstance;
-
-  const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
-
-  if (!projectId || projectId === "your_project_id_here") {
-    // Return mock client when Sanity is not configured
-    return { fetch: async () => null } as unknown as SanityClient;
-  }
-
-  // Dynamic import to avoid build-time issues
-  const { createClient } = require("@sanity/client");
-  clientInstance = createClient({
-    projectId,
-    dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
-    apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2024-03-05",
-    useCdn: true,
-    perspective: "published",
-  }) as SanityClient;
-
-  return clientInstance;
-}
-
-function getBuilder() {
-  if (builderInstance) return builderInstance;
-  const { default: imageUrlBuilder } = require("@sanity/image-url");
-  builderInstance = imageUrlBuilder(getClient());
-  return builderInstance;
-}
-
-// Export a proxy that lazy-loads the client
-export const client = new Proxy({} as SanityClient, {
-  get(_target, prop) {
-    const actualClient = getClient();
-    return actualClient ? actualClient[prop as keyof SanityClient] : undefined;
-  },
-});
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function urlFor(source: any) {
-  try {
-    const builder = getBuilder();
-    if (!builder) {
-      throw new Error("Builder not available");
-    }
-    return builder.image(source);
-  } catch {
-    return {
-      url: () => "/images/placeholder.jpg",
-      width: () => ({ url: () => "/images/placeholder.jpg" }),
-      height: () => ({ url: () => "/images/placeholder.jpg" }),
-    };
-  }
-}
 
 export type Language = "no" | "en";
 
@@ -85,11 +23,72 @@ export function getLocalizedValue(
   return field[lang] ?? field.en ?? field.no ?? null;
 }
 
-// QUERIES
+export function blocksToText(
+  blocks: Array<{ children?: Array<{ text: string }> }> | undefined
+): string {
+  if (!blocks || !Array.isArray(blocks)) return "";
+  return blocks
+    .map((b) => (b.children || []).map((c) => c.text).join(""))
+    .join("\n\n");
+}
+
+export function urlFor(source: { asset?: { _ref?: string } } | null | undefined) {
+  const fallback = { url: () => "/images/placeholder.jpg" };
+  if (!source?.asset?._ref) return fallback;
+
+  const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+  const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || "production";
+  if (!projectId || projectId === "your_project_id_here") return fallback;
+
+  // ref format: image-<hash>-<WxH>-<ext>
+  const parts = source.asset._ref.split("-");
+  if (parts.length < 4) return fallback;
+  const [, hash, dimensions, ext] = parts;
+  const filename = `${hash}-${dimensions}.${ext}`;
+
+  return {
+    url: () => `https://cdn.sanity.io/images/${projectId}/${dataset}/${filename}`,
+  };
+}
+
+async function sanityFetch<T>(
+  query: string,
+  params?: Record<string, string>
+): Promise<T | null> {
+  const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+  if (!projectId || projectId === "your_project_id_here") return null;
+
+  const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || "production";
+  const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2024-03-05";
+  const useCdn = process.env.NODE_ENV === "production";
+  const subdomain = useCdn ? "apicdn" : "api";
+
+  const url = new URL(
+    `https://${projectId}.${subdomain}.sanity.io/v${apiVersion}/data/query/${dataset}`
+  );
+  url.searchParams.set("query", query);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(`$${key}`, JSON.stringify(value));
+    }
+  }
+
+  const res = await fetch(url.toString(), {
+    next: { revalidate: 300 },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Sanity API ${res.status}: ${res.statusText}`);
+  }
+
+  const data = await res.json();
+  return data.result as T;
+}
+
 export async function getSiteSettings(): Promise<SiteSettings | null> {
   try {
-    const query = `*[_type == "siteSettings"][0]`;
-    return (await client.fetch(query)) || null;
+    return await sanityFetch<SiteSettings>(`*[_type == "siteSettings"][0]`);
   } catch (err) {
     logger.error("getSiteSettings failed", err instanceof Error ? err : new Error(String(err)));
     return null;
@@ -98,8 +97,7 @@ export async function getSiteSettings(): Promise<SiteSettings | null> {
 
 export async function getHeroSection(): Promise<HeroSection | null> {
   try {
-    const query = `*[_type == "heroSection"][0]`;
-    return (await client.fetch(query)) || null;
+    return await sanityFetch<HeroSection>(`*[_type == "heroSection"][0]`);
   } catch (err) {
     logger.error("getHeroSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
@@ -108,8 +106,7 @@ export async function getHeroSection(): Promise<HeroSection | null> {
 
 export async function getAboutSection(): Promise<AboutSection | null> {
   try {
-    const query = `*[_type == "aboutSection"][0]`;
-    return (await client.fetch(query)) || null;
+    return await sanityFetch<AboutSection>(`*[_type == "aboutSection"][0]`);
   } catch (err) {
     logger.error("getAboutSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;
@@ -121,7 +118,7 @@ export async function getTeamMembers(): Promise<TeamMember[]> {
     const query = `*[_type == "teamMember"] | order(order asc) {
       _id, name, role, image, bio, linkedin, order
     }`;
-    return (await client.fetch(query)) || [];
+    return (await sanityFetch<TeamMember[]>(query)) || [];
   } catch (err) {
     logger.error("getTeamMembers failed", err instanceof Error ? err : new Error(String(err)));
     return [];
@@ -132,9 +129,9 @@ export async function getNewsArticles(limit?: number): Promise<NewsArticle[]> {
   try {
     const limitClause = limit ? `[0...${limit}]` : "";
     const query = `*[_type == "newsArticle"] | order(publishedAt desc) ${limitClause} {
-      _id, title, slug, excerpt, image, publishedAt, featured
+      _id, title, slug, excerpt, content, image, publishedAt, featured
     }`;
-    return (await client.fetch(query)) || [];
+    return (await sanityFetch<NewsArticle[]>(query)) || [];
   } catch (err) {
     logger.error("getNewsArticles failed", err instanceof Error ? err : new Error(String(err)));
     return [];
@@ -144,17 +141,19 @@ export async function getNewsArticles(limit?: number): Promise<NewsArticle[]> {
 export async function getNewsArticleBySlug(slug: string): Promise<NewsArticle | null> {
   try {
     const query = `*[_type == "newsArticle" && slug.current == $slug][0]`;
-    return (await client.fetch(query, { slug })) || null;
+    return await sanityFetch<NewsArticle>(query, { slug });
   } catch (err) {
-    logger.error(`getNewsArticleBySlug failed: ${slug}`, err instanceof Error ? err : new Error(String(err)));
+    logger.error(
+      `getNewsArticleBySlug failed: ${slug}`,
+      err instanceof Error ? err : new Error(String(err))
+    );
     return null;
   }
 }
 
 export async function getContactSection(): Promise<ContactSection | null> {
   try {
-    const query = `*[_type == "contactSection"][0]`;
-    return (await client.fetch(query)) || null;
+    return await sanityFetch<ContactSection>(`*[_type == "contactSection"][0]`);
   } catch (err) {
     logger.error("getContactSection failed", err instanceof Error ? err : new Error(String(err)));
     return null;

--- a/app/features/home/components/News.tsx
+++ b/app/features/home/components/News.tsx
@@ -115,7 +115,7 @@ export default function News({ initialItems }: { initialItems?: NewsItem[] }) {
         });
       }
     }
-  }, [searchParams, newsItems.length]);
+  }, [searchParams, newsItems]);
 
   const openNews = useCallback((index: number) => {
     setSelected(index);

--- a/app/features/home/components/News.tsx
+++ b/app/features/home/components/News.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { memo, useCallback, useRef } from "react";
 import { FadeIn } from "../../../shared/components/animations/ScrollReveal";
 import { useLanguage } from "../../../shared/providers/LanguageProvider";
-import { newsItems, localize, type NewsItem } from "../../../lib/data/news";
+import { newsItems as staticNewsItems, localize, type NewsItem } from "../../../lib/data/news";
 import { useState, useEffect } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
@@ -86,7 +86,8 @@ const NewsCard = memo(function NewsCard({
   );
 });
 
-export default function News() {
+export default function News({ initialItems }: { initialItems?: NewsItem[] }) {
+  const newsItems = initialItems && initialItems.length > 0 ? initialItems : staticNewsItems;
   const { lang, t } = useLanguage();
   const router = useRouter();
   const pathname = usePathname();
@@ -114,7 +115,7 @@ export default function News() {
         });
       }
     }
-  }, [searchParams]);
+  }, [searchParams, newsItems.length]);
 
   const openNews = useCallback((index: number) => {
     setSelected(index);

--- a/app/features/home/components/Team.tsx
+++ b/app/features/home/components/Team.tsx
@@ -5,11 +5,12 @@ import { Linkedin, Mail } from "lucide-react";
 import { SwoopIn, ElasticSnap } from "../../../shared/components/animations/SwoopAnimations";
 import { SpotlightCard, TiltCard } from "../../../shared/components/ui/PremiumHover";
 import { useLanguage } from "../../../shared/providers/LanguageProvider";
-import { members } from "../../../lib/data/members";
+import { members as staticMembers, type Member } from "../../../lib/data/members";
 import { motion } from "framer-motion";
 
-export default function Team() {
-  const { t } = useLanguage();
+export default function Team({ initialMembers }: { initialMembers?: Member[] }) {
+  const { lang, t } = useLanguage();
+  const members = initialMembers && initialMembers.length > 0 ? initialMembers : staticMembers;
 
   return (
     <section id="team" className="py-28 md:py-40 border-t border-white/[0.07]">
@@ -21,66 +22,70 @@ export default function Team() {
         </SwoopIn>
 
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-6 max-w-[680px]">
-          {members.map((member, i) => (
-            <ElasticSnap key={member.name} delay={0.1 + i * 0.1}>
-              <TiltCard>
-                <SpotlightCard className="h-full group">
-                  {/* Image */}
-                  <div className="relative w-full aspect-[3/4] overflow-hidden rounded-lg mb-4">
-                  <Image
-                    src={member.image}
-                    alt={`${member.name} - ${member.role} at DuxPace`}
-                    fill
-                    loading={i < 2 ? "eager" : "lazy"}
-                    sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 220px"
-                    placeholder="blur"
-                    blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvL0A9Ljo7Ujo4P0ZDS0dMTU5PUVVDWkRHQ11VT0tUVVZfW//2wBDAR..."
-                    className="object-cover object-top transition-transform duration-500 group-hover:scale-105"
-                  />
-                    {/* Overlay on hover */}
-                    <motion.div
-                      className="absolute inset-0 bg-gradient-to-t from-blue-600/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+          {members.map((member, i) => {
+            const role = lang === "no" && member.roleNo ? member.roleNo : member.role;
+            const bio = lang === "no" && member.bioNo ? member.bioNo : member.bio;
+            return (
+              <ElasticSnap key={member.name} delay={0.1 + i * 0.1}>
+                <TiltCard>
+                  <SpotlightCard className="h-full group">
+                    {/* Image */}
+                    <div className="relative w-full aspect-[3/4] overflow-hidden rounded-lg mb-4">
+                    <Image
+                      src={member.image}
+                      alt={`${member.name} - ${role} at DuxPace`}
+                      fill
+                      loading={i < 2 ? "eager" : "lazy"}
+                      sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 220px"
+                      placeholder="blur"
+                      blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvL0A9Ljo7Ujo4P0ZDS0dMTU5PUVVDWkRHQ11VT0tUVVZfW//2wBDAR..."
+                      className="object-cover object-top transition-transform duration-500 group-hover:scale-105"
                     />
-                  </div>
-                  
-                  {/* Content */}
-                  <h3 className="text-white text-sm font-bold leading-snug group-hover:text-blue-300 transition-colors">
-                    {member.name}
-                  </h3>
-                  <p className="text-blue-400/80 text-xs mt-1 font-mono tracking-wider">
-                    {member.role}
-                  </p>
-                  {member.bio && (
-                    <p className="text-gray-500 text-[11px] mt-2 leading-relaxed">
-                      {member.bio}
+                      {/* Overlay on hover */}
+                      <motion.div
+                        className="absolute inset-0 bg-gradient-to-t from-blue-600/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                      />
+                    </div>
+
+                    {/* Content */}
+                    <h3 className="text-white text-sm font-bold leading-snug group-hover:text-blue-300 transition-colors">
+                      {member.name}
+                    </h3>
+                    <p className="text-blue-400/80 text-xs mt-1 font-mono tracking-wider">
+                      {role}
                     </p>
-                  )}
-                  
-                  {/* Social icons */}
-                  <div className="flex gap-3 mt-4">
-                    <motion.a
-                      href={member.linkedin}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center text-gray-400 hover:text-white hover:bg-blue-500/20 transition-all"
-                      whileHover={{ scale: 1.2, rotate: 10 }}
-                      whileTap={{ scale: 0.9 }}
-                    >
-                      <Linkedin size={14} />
-                    </motion.a>
-                    <motion.a
-                      href={`mailto:${member.email}`}
-                      className="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center text-gray-400 hover:text-white hover:bg-blue-500/20 transition-all"
-                      whileHover={{ scale: 1.2, rotate: -10 }}
-                      whileTap={{ scale: 0.9 }}
-                    >
-                      <Mail size={14} />
-                    </motion.a>
-                  </div>
-                </SpotlightCard>
-              </TiltCard>
-            </ElasticSnap>
-          ))}
+                    {bio && (
+                      <p className="text-gray-500 text-[11px] mt-2 leading-relaxed">
+                        {bio}
+                      </p>
+                    )}
+
+                    {/* Social icons */}
+                    <div className="flex gap-3 mt-4">
+                      <motion.a
+                        href={member.linkedin}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center text-gray-400 hover:text-white hover:bg-blue-500/20 transition-all"
+                        whileHover={{ scale: 1.2, rotate: 10 }}
+                        whileTap={{ scale: 0.9 }}
+                      >
+                        <Linkedin size={14} />
+                      </motion.a>
+                      <motion.a
+                        href={`mailto:${member.email}`}
+                        className="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center text-gray-400 hover:text-white hover:bg-blue-500/20 transition-all"
+                        whileHover={{ scale: 1.2, rotate: -10 }}
+                        whileTap={{ scale: 0.9 }}
+                      >
+                        <Mail size={14} />
+                      </motion.a>
+                    </div>
+                  </SpotlightCard>
+                </TiltCard>
+              </ElasticSnap>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/app/lib/data/members.ts
+++ b/app/lib/data/members.ts
@@ -1,8 +1,10 @@
 export type Member = {
   name: string;
   role: string;
+  roleNo?: string;
   image: string;
   bio: string;
+  bioNo?: string;
   linkedin: string;
   email: string;
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,11 +23,11 @@ function formatDate(isoDate: string, locale: string): string {
 function adaptNews(articles: NewsArticle[]): NewsItem[] {
   return articles.map((a) => ({
     image: a.image ? urlFor(a.image).url() : "/images/placeholder.jpg",
-    alt: a.title.en || a.title.no || "",
+    alt: a.title?.en || a.title?.no || "",
     date: a.publishedAt ? formatDate(a.publishedAt, "en-US") : "",
     dateNo: a.publishedAt ? formatDate(a.publishedAt, "nb-NO") : "",
-    title: a.title.en || a.title.no || "",
-    titleNo: a.title.no || a.title.en || "",
+    title: a.title?.en || a.title?.no || "",
+    titleNo: a.title?.no || a.title?.en || "",
     description: a.excerpt?.en || a.excerpt?.no || "",
     descriptionNo: a.excerpt?.no || a.excerpt?.en || "",
     content: blocksToText(a.content?.en),
@@ -38,8 +38,8 @@ function adaptNews(articles: NewsArticle[]): NewsItem[] {
 function adaptTeam(sanityMembers: TeamMember[]): Member[] {
   return sanityMembers.map((m) => ({
     name: m.name,
-    role: m.role.en || m.role.no || "",
-    roleNo: m.role.no || m.role.en || "",
+    role: m.role?.en || m.role?.no || "",
+    roleNo: m.role?.no || m.role?.en || "",
     image: m.image ? urlFor(m.image).url() : "/images/placeholder.jpg",
     bio: m.bio?.en || m.bio?.no || "",
     bioNo: m.bio?.no || m.bio?.en || "",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,62 @@
 import { Suspense } from "react";
 import { Navbar } from "./features/layout";
 import { Hero, About, Team, News, Contact, Footer } from "./features/home";
+import { getNewsArticles, getTeamMembers, urlFor, blocksToText } from "./_lib/sanity";
+import { newsItems as staticNews } from "./lib/data/news";
+import { members as staticMembers } from "./lib/data/members";
+import type { NewsItem } from "./lib/data/news";
+import type { Member } from "./lib/data/members";
+import type { NewsArticle, TeamMember } from "@/types/sanity";
 
-export default function Home() {
+function formatDate(isoDate: string, locale: string): string {
+  try {
+    return new Date(isoDate).toLocaleDateString(locale, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch {
+    return isoDate;
+  }
+}
+
+function adaptNews(articles: NewsArticle[]): NewsItem[] {
+  return articles.map((a) => ({
+    image: a.image ? urlFor(a.image).url() : "/images/placeholder.jpg",
+    alt: a.title.en || a.title.no || "",
+    date: a.publishedAt ? formatDate(a.publishedAt, "en-US") : "",
+    dateNo: a.publishedAt ? formatDate(a.publishedAt, "nb-NO") : "",
+    title: a.title.en || a.title.no || "",
+    titleNo: a.title.no || a.title.en || "",
+    description: a.excerpt?.en || a.excerpt?.no || "",
+    descriptionNo: a.excerpt?.no || a.excerpt?.en || "",
+    content: blocksToText(a.content?.en),
+    contentNo: blocksToText(a.content?.no),
+  }));
+}
+
+function adaptTeam(sanityMembers: TeamMember[]): Member[] {
+  return sanityMembers.map((m) => ({
+    name: m.name,
+    role: m.role.en || m.role.no || "",
+    roleNo: m.role.no || m.role.en || "",
+    image: m.image ? urlFor(m.image).url() : "/images/placeholder.jpg",
+    bio: m.bio?.en || m.bio?.no || "",
+    bioNo: m.bio?.no || m.bio?.en || "",
+    linkedin: m.linkedin || "",
+    email: "planet@duxpace.no",
+  }));
+}
+
+export default async function Home() {
+  const [sanityNews, sanityTeam] = await Promise.all([
+    getNewsArticles(),
+    getTeamMembers(),
+  ]);
+
+  const newsData = sanityNews.length > 0 ? adaptNews(sanityNews) : staticNews;
+  const teamData = sanityTeam.length > 0 ? adaptTeam(sanityTeam) : staticMembers;
+
   return (
     <>
       {/* Skip to main content for accessibility */}
@@ -14,17 +68,17 @@ export default function Home() {
       </a>
 
       <Navbar />
-      
+
       <main id="main-content">
         <Hero />
         <About />
-        <Team />
+        <Team initialMembers={teamData} />
         <Suspense fallback={<div className="py-20 text-center text-gray-500">Loading news...</div>}>
-          <News />
+          <News initialItems={newsData} />
         </Suspense>
         <Contact />
       </main>
-      
+
       <Footer />
     </>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     remotePatterns: [
       { protocol: "https", hostname: "images.unsplash.com" },
+      { protocol: "https", hostname: "cdn.sanity.io" },
     ],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],


### PR DESCRIPTION
Closes #61.

Replaces static TypeScript arrays for news articles and team members with live data fetched from Sanity CMS. The Sanity client is implemented using native `fetch()` against the REST API, removing the need for the `@sanity/client` package. When Sanity is not configured or returns no results, the site falls back to the existing static data so the page always renders. Team member roles and bios now support Norwegian localization when a Sanity entry carries both language variants.