### PR TITLE
remove cookies() from generateMetadata to restore static metadata generation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,12 +22,8 @@ export const viewport: Viewport = {
   themeColor: "#000000",
 };
 
-export async function generateMetadata(): Promise<Metadata> {
-  const cookieStore = await cookies();
-  const rawLang = cookieStore.get("lang")?.value;
-  const lang: Language = rawLang === "en" || rawLang === "no" ? rawLang : "en";
-  const { title, description } = translations[lang].meta;
-  const ogLocale = lang === "no" ? "nb_NO" : "en_US";
+export function generateMetadata(): Metadata {
+  const { title, description } = translations.en.meta;
 
   return {
     metadataBase: new URL("https://duxpace.no"),
@@ -58,8 +54,8 @@ export async function generateMetadata(): Promise<Metadata> {
       description,
       url: "https://duxpace.no",
       siteName: "DuxPace",
-      locale: ogLocale,
-      alternateLocale: lang === "no" ? "en_US" : "nb_NO",
+      locale: "en_US",
+      alternateLocale: "nb_NO",
       type: "website",
       images: [{ url: "/images/logos/logo-banner.jpeg", width: 1200, height: 630, alt: "DuxPace" }],
     },


### PR DESCRIPTION
Closes #70.

`generateMetadata` was calling `await cookies()` to pick a language-aware title, which is a Dynamic API and opts the entire route out of static generation in Next.js 16. Social media crawlers and search engines don't send cookies anyway, so the personalisation had no effect on them. The fix makes `generateMetadata` a plain synchronous function using the English canonical metadata, which Next.js can resolve at build time. The `cookies()` call in `RootLayout` is retained as-is since it only drives the HTML `lang` attribute for the SSR shell.