### PR TITLE
fix sanity image fallback to use existing logo-square.jpeg

### DIFF
--- a/app/_lib/sanity.ts
+++ b/app/_lib/sanity.ts
@@ -33,7 +33,7 @@ export function blocksToText(
 }
 
 export function urlFor(source: { asset?: { _ref?: string } } | null | undefined) {
-  const fallback = { url: () => "/images/placeholder.jpg" };
+  const fallback = { url: () => "/images/logos/logo-square.jpeg" };
   if (!source?.asset?._ref) return fallback;
 
   const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;

--- a/app/features/home/components/News.tsx
+++ b/app/features/home/components/News.tsx
@@ -52,6 +52,7 @@ const NewsCard = memo(function NewsCard({
               loading="lazy"
               sizes="(max-width: 768px) 100vw, 33vw"
               className="object-cover transition-transform duration-500 group-hover:scale-105"
+              onError={(e) => { e.currentTarget.srcset = ""; e.currentTarget.src = "/images/logos/logo-square.jpeg"; }}
             />
             {/* Date badge */}
             <div className="absolute top-3 left-3">
@@ -297,7 +298,7 @@ export default function News({ initialItems }: { initialItems?: NewsItem[] }) {
               transition={shouldReduce ? { duration: 0.15 } : { duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
             >
               <div className="relative w-full aspect-video">
-                <Image src={item.image} alt={item.alt} fill className="object-cover" />
+                <Image src={item.image} alt={item.alt} fill className="object-cover" onError={(e) => { e.currentTarget.srcset = ""; e.currentTarget.src = "/images/logos/logo-square.jpeg"; }} />
                 <motion.button
                   ref={closeButtonRef}
                   onClick={closeModal}

--- a/app/features/home/components/Team.tsx
+++ b/app/features/home/components/Team.tsx
@@ -37,6 +37,7 @@ export default function Team({ initialMembers }: { initialMembers?: Member[] }) 
                       fill
                       loading={i < 2 ? "eager" : "lazy"}
                       sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 220px"
+                      onError={(e) => { e.currentTarget.srcset = ""; e.currentTarget.src = "/images/logos/logo-square.jpeg"; }}
                       placeholder="blur"
                       blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvL0A9Ljo7Ujo4P0ZDS0dMTU5PUVVDWkRHQ11VT0tUVVZfW//2wBDAR..."
                       className="object-cover object-top transition-transform duration-500 group-hover:scale-105"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ function formatDate(isoDate: string, locale: string): string {
 
 function adaptNews(articles: NewsArticle[]): NewsItem[] {
   return articles.map((a) => ({
-    image: a.image ? urlFor(a.image).url() : "/images/placeholder.jpg",
+    image: a.image ? urlFor(a.image).url() : "/images/logos/logo-square.jpeg",
     alt: a.title?.en || a.title?.no || "",
     date: a.publishedAt ? formatDate(a.publishedAt, "en-US") : "",
     dateNo: a.publishedAt ? formatDate(a.publishedAt, "nb-NO") : "",
@@ -40,7 +40,7 @@ function adaptTeam(sanityMembers: TeamMember[]): Member[] {
     name: m.name,
     role: m.role?.en || m.role?.no || "",
     roleNo: m.role?.no || m.role?.en || "",
-    image: m.image ? urlFor(m.image).url() : "/images/placeholder.jpg",
+    image: m.image ? urlFor(m.image).url() : "/images/logos/logo-square.jpeg",
     bio: m.bio?.en || m.bio?.no || "",
     bioNo: m.bio?.no || m.bio?.en || "",
     linkedin: m.linkedin || "",


### PR DESCRIPTION
Closes #74.

The fallback path /images/placeholder.jpg referenced in the urlFor() helper and two adapter functions in page.tsx did not exist in public/, causing 404 errors and broken images whenever Sanity was unconfigured. Changed all three references to /images/logos/logo-square.jpeg, which already exists. Also added onError handlers to the three affected next/image components in News.tsx and Team.tsx so client-side load failures (e.g. broken Unsplash URLs in static data) also degrade gracefully to the same fallback.