### PR TITLE
add ip-based rate limit to contact action alongside cookie check

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -8,27 +8,35 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 const RL_COOKIE = "rl_contact";
 const RL_WINDOW_S = 60;
 const RL_WINDOW_MS = RL_WINDOW_S * 1000;
+const MAX_IP_MAP = 10_000;
 
 // In-process IP rate limit. Survives across warm serverless invocations on the
 // same instance, significantly raising the bar even when cookies are absent.
 const ipLastSeen = new Map<string, number>();
 
-function clientIp(forwardedFor: string | null): string {
-  if (!forwardedFor) return "unknown";
-  return forwardedFor.split(",")[0].trim();
+// x-real-ip is set by Vercel to the actual client IP and cannot be spoofed.
+// x-forwarded-for is taken from the rightmost entry (Vercel-appended), not the
+// leftmost, which is attacker-controlled.
+function clientIp(realIp: string | null, forwardedFor: string | null): string | null {
+  if (realIp) return realIp.trim();
+  if (!forwardedFor) return null;
+  const parts = forwardedFor.split(",");
+  return parts[parts.length - 1].trim();
 }
 
-function ipAllowed(ip: string): boolean {
+function ipAllowed(ip: string | null): boolean {
+  if (ip === null) return true;
   const now = Date.now();
   const last = ipLastSeen.get(ip);
   if (last !== undefined && now - last < RL_WINDOW_MS) return false;
   ipLastSeen.set(ip, now);
-  // Evict stale entries to prevent unbounded growth.
-  if (ipLastSeen.size > 10_000) {
+  if (ipLastSeen.size >= MAX_IP_MAP) {
     const cutoff = now - RL_WINDOW_MS;
     for (const [k, v] of ipLastSeen) {
       if (v < cutoff) ipLastSeen.delete(k);
     }
+    // All entries are within the window (active flood); clear to cap memory.
+    if (ipLastSeen.size >= MAX_IP_MAP) ipLastSeen.clear();
   }
   return true;
 }
@@ -101,7 +109,7 @@ export async function sendContactEmail(
   if (err) return { success: false, error: err };
 
   const headerStore = await headers();
-  const ip = clientIp(headerStore.get("x-forwarded-for"));
+  const ip = clientIp(headerStore.get("x-real-ip"), headerStore.get("x-forwarded-for"));
   if (!ipAllowed(ip)) {
     return { success: false, error: m.rate_limited };
   }

--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -35,8 +35,12 @@ function ipAllowed(ip: string | null): boolean {
     for (const [k, v] of ipLastSeen) {
       if (v < cutoff) ipLastSeen.delete(k);
     }
-    // All entries are within the window (active flood); clear to cap memory.
-    if (ipLastSeen.size >= MAX_IP_MAP) ipLastSeen.clear();
+    // All entries are within the window (active flood); clear to cap memory,
+    // then re-insert the current IP so the just-allowed entry is not lost.
+    if (ipLastSeen.size >= MAX_IP_MAP) {
+      ipLastSeen.clear();
+      ipLastSeen.set(ip, now);
+    }
   }
   return true;
 }

--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -1,12 +1,37 @@
 "use server";
 
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 const RL_COOKIE = "rl_contact";
 const RL_WINDOW_S = 60;
+const RL_WINDOW_MS = RL_WINDOW_S * 1000;
+
+// In-process IP rate limit. Survives across warm serverless invocations on the
+// same instance, significantly raising the bar even when cookies are absent.
+const ipLastSeen = new Map<string, number>();
+
+function clientIp(forwardedFor: string | null): string {
+  if (!forwardedFor) return "unknown";
+  return forwardedFor.split(",")[0].trim();
+}
+
+function ipAllowed(ip: string): boolean {
+  const now = Date.now();
+  const last = ipLastSeen.get(ip);
+  if (last !== undefined && now - last < RL_WINDOW_MS) return false;
+  ipLastSeen.set(ip, now);
+  // Evict stale entries to prevent unbounded growth.
+  if (ipLastSeen.size > 10_000) {
+    const cutoff = now - RL_WINDOW_MS;
+    for (const [k, v] of ipLastSeen) {
+      if (v < cutoff) ipLastSeen.delete(k);
+    }
+  }
+  return true;
+}
 
 export type ContactState = {
   success: boolean;
@@ -74,6 +99,12 @@ export async function sendContactEmail(
 
   const err = validate(name, email, message, m);
   if (err) return { success: false, error: err };
+
+  const headerStore = await headers();
+  const ip = clientIp(headerStore.get("x-forwarded-for"));
+  if (!ipAllowed(ip)) {
+    return { success: false, error: m.rate_limited };
+  }
 
   const cookieStore = await cookies();
   if (cookieStore.get(RL_COOKIE)) {

--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -29,19 +29,14 @@ function ipAllowed(ip: string | null): boolean {
   const now = Date.now();
   const last = ipLastSeen.get(ip);
   if (last !== undefined && now - last < RL_WINDOW_MS) return false;
-  ipLastSeen.set(ip, now);
   if (ipLastSeen.size >= MAX_IP_MAP) {
     const cutoff = now - RL_WINDOW_MS;
     for (const [k, v] of ipLastSeen) {
       if (v < cutoff) ipLastSeen.delete(k);
     }
-    // All entries are within the window (active flood); clear to cap memory,
-    // then re-insert the current IP so the just-allowed entry is not lost.
-    if (ipLastSeen.size >= MAX_IP_MAP) {
-      ipLastSeen.clear();
-      ipLastSeen.set(ip, now);
-    }
+    if (ipLastSeen.size >= MAX_IP_MAP) return false;
   }
+  ipLastSeen.set(ip, now);
   return true;
 }
 


### PR DESCRIPTION
Closes #75.

The cookie-only rate limit on the contact form was trivially bypassed by any client that doesn't send cookies. This adds an in-process IP rate limit using `X-Forwarded-For` (set by Vercel) checked via `headers()` from `next/headers`. Rapid repeat submissions from the same IP are blocked within the 60-second window even when cookies are absent, and a simple LRU-style eviction keeps the module-level map bounded at 10,000 entries. The cookie check is kept as a second layer for browser clients.