### PR TITLE
fix(contact): drop bot submissions with a honeypot field

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -68,6 +68,13 @@ export async function sendContactEmail(
   const lang = formData.get("lang") === "no" ? "no" : "en";
   const m = MESSAGES[lang];
 
+  // Honeypot: a hidden field real users never see. Bots fill every input, so a
+  // non-empty value means an automated submission. Report success without
+  // sending, so the bot gets no signal that it was caught.
+  if (formData.get("company")?.toString().trim()) {
+    return { success: true };
+  }
+
   const name = formData.get("name")?.toString().trim() ?? "";
   const email = formData.get("email")?.toString().trim().toLowerCase() ?? "";
   const message = formData.get("message")?.toString().trim() ?? "";

--- a/app/features/home/components/Contact.tsx
+++ b/app/features/home/components/Contact.tsx
@@ -45,6 +45,18 @@ function ContactForm({ onReset }: { onReset: () => void }) {
   return (
     <form action={action} className="space-y-5">
       <input type="hidden" name="lang" value={lang} />
+      {/* Honeypot: off-screen and hidden from assistive tech. Real users never
+          fill it; bots do, and the server drops those submissions. */}
+      <div className="absolute left-[-9999px]" aria-hidden="true">
+        <label htmlFor="contact-company">Company</label>
+        <input
+          id="contact-company"
+          type="text"
+          name="company"
+          tabIndex={-1}
+          autoComplete="off"
+        />
+      </div>
       <div>
         <label htmlFor="contact-name" className="block text-xs text-gray-400 mb-1.5">
           {t.contact.nameLabel}


### PR DESCRIPTION
Closes #38.

The contact form had no bot protection. Added an off-screen, `aria-hidden`, `tabIndex={-1}` honeypot field named `company`:

- **Contact.tsx**: hidden field positioned off-screen (`absolute left-[-9999px]`), hidden from assistive tech, removed from tab order, `autoComplete="off"`. No visual or layout change, no a11y impact.
- **contact.ts**: if `company` arrives non-empty, the action returns `{ success: true }` without sending, so the bot gets no signal it was caught.

Scoped to #38 only. The cookie-based rate limit (#75) is a separate architectural question (a real server-side limit needs a shared store like Upstash/Redis, which would add a vendor to the stack) and is left to the team; I'll note a recommendation on that issue.

Verified: `npm run build` succeeds and statically prerenders all routes; the two changed files are eslint-clean. The repo's other lint/type errors live in the untracked local `marketing-site-skills/` scratch dir, which is not on main.