### PR TITLE
fix(globe): wrap InteractiveGlobe in an error boundary

### DIFF
--- a/app/shared/components/GlobeWrapper.tsx
+++ b/app/shared/components/GlobeWrapper.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useRef, useState, useEffect } from "react";
+import { Component, useRef, useState, useEffect, type ReactNode } from "react";
 
-const InteractiveGlobe = dynamic(() => import("./InteractiveGlobe"), { 
+const InteractiveGlobe = dynamic(() => import("./InteractiveGlobe"), {
   ssr: false,
   loading: () => (
     <div className="w-full aspect-square flex items-center justify-center">
@@ -11,6 +11,30 @@ const InteractiveGlobe = dynamic(() => import("./InteractiveGlobe"), {
     </div>
   )
 });
+
+// The globe runs WebGL. On hardware or driver failure the render throws, and
+// without a boundary that crash takes the whole page down. Catch it here and
+// fall back to a quiet static placeholder so the rest of the page survives.
+// The globe is decorative, so the fallback carries no copy and is hidden from
+// assistive tech; it only holds the layout so nothing around it shifts.
+class GlobeErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("InteractiveGlobe failed to render:", error);
+  }
+
+  render() {
+    if (this.state.failed) {
+      return <div className="w-full aspect-square" aria-hidden="true" />;
+    }
+    return this.props.children;
+  }
+}
 
 export default function GlobeWrapper() {
   const ref = useRef<HTMLDivElement>(null);
@@ -39,7 +63,11 @@ export default function GlobeWrapper() {
 
   return (
     <div ref={ref} className="w-full h-full">
-      {isVisible ? <InteractiveGlobe /> : (
+      {isVisible ? (
+        <GlobeErrorBoundary>
+          <InteractiveGlobe />
+        </GlobeErrorBoundary>
+      ) : (
         <div className="w-full aspect-square flex items-center justify-center">
           <div className="w-8 h-8 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
         </div>


### PR DESCRIPTION
Closes #54.

The globe renders via WebGL. On hardware/driver failure that render throws, and with no boundary the unhandled error unmounts the whole page.

Added a small class-based `GlobeErrorBoundary` in `GlobeWrapper.tsx` (no new file, no new dep) around `InteractiveGlobe`. On a render failure it logs the error via `componentDidCatch` and renders a quiet static placeholder that holds the same `aspect-square` space, so the page keeps working and surrounding layout does not shift. The placeholder is `aria-hidden` since the globe is decorative.

Verified: `npm run build` compiles and statically prerenders all routes; the file is eslint-clean.